### PR TITLE
Remove the /tmp/xcat-dep from the localhost before starting the playbook

### DIFF
--- a/ansible/ipmitool-xcat/roles/ipmitool-xcat/tasks/main.yml
+++ b/ansible/ipmitool-xcat/roles/ipmitool-xcat/tasks/main.yml
@@ -1,13 +1,18 @@
 ---
 
-- name: Delete xcat-dep directory on remote
+- name: Delete the xcat-dep from localhost
   file: path="{{ xcat_dep_path }}" state=absent
+  delegate_to: localhost
+  run_once: true
 
-- name: Get xcat-dep from github
+- name: Get xcat-dep from GitHub to localhost
   git: repo="{{ xcat_dep_url }}"
        dest="{{ xcat_dep_path }}"
   delegate_to: localhost
   run_once: true
+
+- name: Delete xcat-dep directory on remote
+  file: path="{{ xcat_dep_path }}" state=absent
 
 - name: Create xcat-dep directory
   file: path=/tmp/xcat-dep state=directory


### PR DESCRIPTION
I hit this problem when running the playbook, 

```
TASK [ipmitool-xcat : Get xcat-dep from github] **************************************************************************************
fatal: [10.2.5.7 -> localhost]: FAILED! => {"before": "01bd7d96ff64388d0c88c7554d8dd62722132015", "changed": false, "failed": true, "msg": "Local modifications exist in repository (force=no)."}

```

Before we start the playbook and remove directories from the remote nodes, we should clean up so that we can successfully clone the repo. 