### PR TITLE
Attempt to install the development rpms on SLES and fail if SDK repo is not there

### DIFF
--- a/ansible/ipmitool-xcat/README.rst
+++ b/ansible/ipmitool-xcat/README.rst
@@ -11,8 +11,9 @@ Edit ``./ansible/conserver-xcat/inventory/host`` to add hosts where the
 packages are built. If you use sshpass to connect to the hosts, make sure hosts
 key are added in the `known_hosts` file.
 
-Copy rpm dependencies which are needed to complie the openssl library into
-``ansible/ipmitool-xcat/roles/ipmitool-xcat/files`` directory.(Only for sles)
+For SLES, development related RPMs are shipped with the SDK ISO.  Ensure that 
+the `zypper` repo files are confgiured to point to an SDK repo, or the build for
+SLES will not work. 
 
 Example
 -------
@@ -22,7 +23,7 @@ Run the ipmitool-xcat playbook to build packages::
   cd ansible/ipmitool-xcat
   ansible-playbook -i inventory/host ipmitool-xcat.yml
 
-`ipmitool-xcat` packages will be placed in `/tmp/build` directory.
+`ipmitool-xcat` packages will be placed in `/tmp/build` directory on the localhost.
 
 xCAT site
 =========

--- a/ansible/ipmitool-xcat/inventory/host
+++ b/ansible/ipmitool-xcat/inventory/host
@@ -1,16 +1,24 @@
 [redhat]
-10.5.101.64 # th7 x86
-10.5.101.65 # rh6 x86
-10.2.3.2 # rh7 ppc64
-10.2.3.4   # rh6 ppc64
-10.3.29.2  # rh7 ppc64le
+# Focus on RHEL 7
+# x.x.x.x        # rh6 ppc64
+10.2.5.7        # rh7 ppc64
+
+10.4.42.110     # rh7 x86_64
+# x.x.x.x        # rh6 x86_64
+
+10.3.31.180     # rh7.3 ppc64le
+
+
 [ubuntu]
-#testnode1 # ubuntu 16.04
-10.5.101.11 # ubuntu 14.04 x86_64
-10.3.4.10 #ubuntu 14.04 ppc64le
+10.4.42.111     # ubuntu 14.04 x86_64
+10.3.31.182     # ubuntu 14.04.1 ppc64le
 
 [sles]
-10.5.101.70
-10.5.101.72    # x86_64 sles 11.4
-10.3.4.4  # ppc64le sles12
-#10.2.1.25 # ppc64 sles11.4  ansible error
+# Focus on SLES 12 
+
+# x.x.x.x        # sles11 ppc64  (does not work)
+
+# x.x.x.x        # sles11 x86_64
+10.4.42.112     # sles12 x86_64
+
+10.3.31.181     # sles12 ppc64le

--- a/ansible/ipmitool-xcat/roles/ipmitool-xcat/tasks/sles.yml
+++ b/ansible/ipmitool-xcat/roles/ipmitool-xcat/tasks/sles.yml
@@ -1,113 +1,62 @@
 - name: Add execution permission for bldipmi.pl script
   file: path=/tmp/xcat-dep/ipmitool/bldipmi.pl mode=u+x
 
-- name: Create rpms directory
-  file: path=/tmp/rpms state=directory
 
-# for sles 12 x86_64
+# for SLES 12 x86_64
+#
+# the *devel packages are shipped with the SDK iso files and target machine
+# is required to have a repo configured to point to the SDK for this to succeed.
+#
 
-- name: Copy rpm x86 dependencies for sles12
-  copy: src="{{ item }}" dest=/tmp/rpms
-  with_items:
-    - "{{ sles12_x86_openssl_rpm }}"
-    - "{{ sles12_x86_zlib_rpm }}"
-  when: (ansible_distribution_major_version == "12") and
-        (ansible_machine == "x86_64")
-
-- name: install zlib x86 dependency for sles12
-  shell: zypper install -y {{ sles12_x86_zlib_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "12") and
-        (ansible_machine == "x86_64")
-
-- name: install openssl x86 dependency for sles12
-  shell: zypper install -y {{ sles12_x86_openssl_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "12") and
-        (ansible_machine == "x86_64")
-
-- name: install rpmbuild x86 dependency for sles12
+- name: install rpmbuild x86 dependency for SLES12
   zypper: name={{ item }} state=present
   with_items:
     - rpmbuild
+    - gcc
+    - libopenssl-devel
+    - zlib-devel
   when: (ansible_distribution_major_version == "12") and
         (ansible_machine == "x86_64")
 
-# for sles 11.4 x86_64
-- name: Copy rpm x86_64 dependencies for sles11.4
-  copy: src="{{ item }}" dest=/tmp/rpms
-  with_items:
-    - "{{ sles11_4_x86_openssl_rpm }}"
-    - "{{ sles11_4_x86_zlib_rpm }}"
-  when: (ansible_distribution_major_version == "11") and
-        (ansible_machine == "x86_64")
 
-- name: install zlib x86_64 dependency for sles11.4
-  shell: zypper install -y {{ sles11_4_x86_zlib_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "11") and
-        (ansible_machine == "x86_64")
-
-- name: install openssl x86_64 dependency for sles11.4
-  shell: zypper install -y {{ sles11_4_x86_openssl_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "11") and
-        (ansible_machine == "x86_64")
-
-- name: install gcc x86_64 dependency for sles11.4
+# for SLES 11.4 x86_64
+#
+# the *devel packages are shipped with the SDK iso files and target machine
+# is required to have a repo configured to point to the SDK for this to succeed.
+#
+- name: install gcc x86_64 dependency for SLES11.4
   zypper: name={{ item }} state=present
   with_items:
     - gcc
+    - libopenssl-devel
+    - zlib-devel
   when: (ansible_distribution_major_version == "11") and
         (ansible_machine == "x86_64")
 
 
-# for sles 11.4 ppc64
-- name: Copy rpm ppc64 dependencies for sles11.4
-  copy: src="{{ item }}" dest=/tmp/rpms
-  with_items:
-    - "{{ sles11_4_ppc64_openssl_rpm }}"
-    - "{{ sles11_4_ppc64_zlib_rpm }}"
-  when: (ansible_distribution_major_version == "11") and
-        (ansible_machine == "ppc64")
-
-- name: install zlib ppc64 dependency for sles11.4
-  shell: zypper install -y {{ sles11_4_ppc64_zlib_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "11") and
-        (ansible_machine == "ppc64")
-
-- name: install openssl ppc64 dependency for sles11.4
-  shell: zypper install -y {{ sles11_4_ppc64_openssl_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "11") and
-        (ansible_machine == "ppc64")
-
-- name: install gcc ppc64 dependency for sles11.4
+# for SLES 11.4 ppc64
+#
+# the *devel packages are shipped with the SDK iso files and target machine
+# is required to have a repo configured to point to the SDK for this to succeed.
+#
+- name: install gcc ppc64 dependency for SLES11.4
   zypper: name={{ item }} state=present
   with_items:
     - gcc
+    - libopenssl-devel 
+    - zlib-devel
   when: (ansible_distribution_major_version == "11") and
         (ansible_machine == "ppc64")
 
 
-# for sles 12 ppc64le
-- name: Copy rpm ppc64le dependencies for sles12
-  copy: src="{{ item }}" dest=/tmp/rpms
-  with_items:
-    - "{{ sles12_ppc64le_openssl_rpm }}"
-    - "{{ sles12_ppc64le_zlib_rpm }}"
-  when: (ansible_distribution_major_version == "12") and
-        (ansible_machine == "ppc64le")
-
-- name: install zlib ppc64le dependency for sles12
-  shell: zypper install -y {{ sles12_ppc64le_zlib_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "12") and
-        (ansible_machine == "ppc64le")
-
-- name: install openssl ppc64le dependency for sles12
-  shell: zypper install -y {{ sles12_ppc64le_openssl_rpm }} chdir=/tmp/rpms
-  when: (ansible_distribution_major_version == "12") and
-        (ansible_machine == "ppc64le")
-
-- name: install rpmbuild on ppc64le dependency for sles12
+# for SLES 12 ppc64le
+- name: install rpmbuild on ppc64le dependency for SLES12
   zypper: name={{ item }} state=present
   with_items:
     - rpmbuild
+    - gcc
+    - libopenssl-devel 
+    - zlib-devel
   when: (ansible_distribution_major_version == "12") and
         (ansible_machine == "ppc64le")
 


### PR DESCRIPTION
In this pull request, we focus on only the RHEL 7, SLES 12 and Ubuntu 14.04 Operating systems. 

Changes made to not rely on a special directory that contains the SDK rpms, but rather force the user to create a repo file that points to the SDK disk. This will allow us to not have another step to copy out the RPMs.  